### PR TITLE
Do not modify Board

### DIFF
--- a/src/biz/tugay/groovyship/cli/CliGameController.groovy
+++ b/src/biz/tugay/groovyship/cli/CliGameController.groovy
@@ -59,7 +59,7 @@ class CliGameController
         continue
       }
 
-      sendMissile userInput, board
+      board = sendMissile userInput, board
     }
   }
 
@@ -89,19 +89,22 @@ class CliGameController
     }
   }
 
-  private static void sendMissile(String userInput, Board board) {
+  private static Board sendMissile(String userInput, Board board) {
     try {
       def column = parseInt userInput[0]
       def row = parseInt userInput[-1]
-      if (gameService.sendMissile board, column, row) {
+      def (newBoard, isHit) = gameService.sendMissile(board, column, row)
+      if (isHit) {
         println "Hit."
       }
       else {
         println "Missed."
       }
+      return newBoard
     }
     catch (Exception ignored) {
       println "Please provide coordinates in the format: 0,0"
     }
+    return board
   }
 }

--- a/src/biz/tugay/groovyship/service/BoardService.groovy
+++ b/src/biz/tugay/groovyship/service/BoardService.groovy
@@ -29,21 +29,17 @@ class BoardService
   }
 
   /**
-   * Sends a missile to to the board. Returns whether it hit a ship or not.
-   *
-   * @param board The board the missile be sent to
-   * @param column The column of the missile
-   * @param row The row of the missle
-   * @return Whether a ship was hit or not
+   * Sends a missile to to the board.
+   * Returns a new board and the information whether the attempt was successful or not.
    */
-  boolean missileCoordinate(Board board, int column, int row) {
-    def missileCoordinate = Coordinate.of column, row
-    board.missileAttempts << missileCoordinate
+  def missileCoordinate(Board board, int column, int row) {
+    def newBoard = copy(board)
+    newBoard.missileAttempts << Coordinate.of(column, row)
 
     def anyHit = false
-    board.ships.each { { anyHit = anyHit || shipService.attemptMissileHit(it, missileCoordinate) } }
+    newBoard.ships.each { { anyHit = anyHit || shipService.attemptMissileHit(it, Coordinate.of(column, row)) } }
 
-    return anyHit
+    return [newBoard, anyHit]
   }
 
   /**
@@ -52,5 +48,16 @@ class BoardService
    */
   boolean allShipsSank(Board board) {
     return board.ships.every { it.coordinateIsHitByMissileMap.values().every { it } }
+  }
+
+  Board copy(Board board) {
+    def newBoard = new Board(board.boardSize)
+
+    board.missileAttempts.each { newBoard.missileAttempts << it }
+    board.ships.each {
+      newBoard.ships << shipService.copy(it)
+    }
+
+    return newBoard
   }
 }

--- a/src/biz/tugay/groovyship/service/GameService.groovy
+++ b/src/biz/tugay/groovyship/service/GameService.groovy
@@ -32,7 +32,7 @@ class GameService
     return board
   }
 
-  boolean sendMissile(Board board, int column, int row) {
+  def sendMissile(Board board, int column, int row) {
     return boardService.missileCoordinate(board, column, row)
   }
 

--- a/src/biz/tugay/groovyship/service/ShipService.groovy
+++ b/src/biz/tugay/groovyship/service/ShipService.groovy
@@ -102,4 +102,12 @@ class ShipService
   boolean isSank(Ship ship) {
     return ship.coordinateIsHitByMissileMap.values().every { it }
   }
+
+  Ship copy(Ship ship) {
+    def newShip = new Ship()
+    ship.coordinateIsHitByMissileMap.entrySet().forEach(entry -> {
+      newShip.coordinateIsHitByMissileMap.put(Coordinate.of(entry.key.column, entry.key.row), entry.value)
+    })
+    return newShip
+  }
 }

--- a/test/biz/tugay/groovyship/service/BoardServiceTest.groovy
+++ b/test/biz/tugay/groovyship/service/BoardServiceTest.groovy
@@ -38,13 +38,17 @@ class BoardServiceTest
     def ship = new Ship(Coordinate.of(0, 0))
     boardService.addShip(board, ship)
 
-    def hit = boardService.missileCoordinate(board, 1, 0)
-    assertFalse(hit)
-    assertTrue(board.missileAttempts.contains(Coordinate.of(1, 0)))
+    def (newBoard, isMissileHit) = boardService.missileCoordinate(board, 1, 0)
+    assertFalse(isMissileHit)
+    assertFalse(board.missileAttempts.contains(Coordinate.of(1, 0)))
+    assertTrue(newBoard.missileAttempts.contains(Coordinate.of(1, 0)))
 
-    hit = boardService.missileCoordinate(board, 0, 0)
-    assertTrue(hit)
-    assertTrue(board.missileAttempts.contains(Coordinate.of(0, 0)))
+    def (newNewBoard, newIsMissileHit) = boardService.missileCoordinate(board, 0, 0)
+    assertFalse(isMissileHit)
+    assertTrue(newIsMissileHit)
+
+    assertFalse(newBoard.missileAttempts.contains(Coordinate.of(0, 0)))
+    assertTrue(newNewBoard.missileAttempts.contains(Coordinate.of(0, 0)))
   }
 
   @Test
@@ -53,10 +57,25 @@ class BoardServiceTest
     def ship = new Ship(Coordinate.of(0, 0))
     boardService.addShip(board, ship)
 
-    boardService.missileCoordinate(board, 1, 0)
+    def (newBoard, isMissileHit) = boardService.missileCoordinate(board, 0, 0)
     assertFalse(boardService.allShipsSank(board))
 
-    boardService.missileCoordinate(board, 0, 0)
-    assertTrue(boardService.allShipsSank(board))
+    assertTrue(boardService.allShipsSank(newBoard))
+    assertTrue(isMissileHit)
+  }
+
+  @Test
+  void testCopy() {
+    def ship = new Ship()
+    ship.coordinateIsHitByMissileMap.put(Coordinate.of(5, 5), false)
+
+    def board = new Board(4)
+    board.missileAttempts.add(Coordinate.of(4, 4))
+    board.ships.add(ship)
+
+    def newBoard = boardService.copy(board)
+    assertFalse(board.ships.iterator().next().is(newBoard.ships.iterator().next()))
+    assertFalse(board.missileAttempts.is(newBoard.missileAttempts))
+    assertFalse(board.is(newBoard))
   }
 }

--- a/test/biz/tugay/groovyship/service/ShipServiceTest.groovy
+++ b/test/biz/tugay/groovyship/service/ShipServiceTest.groovy
@@ -28,7 +28,8 @@ class ShipServiceTest
       populatedCoordinates.addAll(ship.coordinateIsHitByMissileMap.keySet())
       generatedShipSizes.add(ship.coordinateIsHitByMissileMap.size())
       assertTrue(ship.coordinateIsHitByMissileMap.size() <= boardSize)
-      ship.coordinateIsHitByMissileMap.keySet().each { assertTrue(it.row <= boardSize) && assertTrue(it.column <= boardSize) }
+      ship.coordinateIsHitByMissileMap.keySet().
+          each { assertTrue(it.row <= boardSize) && assertTrue(it.column <= boardSize) }
     }
 
     assertTrue(populatedCoordinates.size() == boardSize * boardSize)
@@ -171,5 +172,21 @@ class ShipServiceTest
     assertFalse(shipService.isSank(ship))
     assertFalse(shipService.attemptMissileHit(ship, Coordinate.of(3, 3)))
     assertFalse(shipService.isSank(ship))
+  }
+
+  @Test
+  void testCopy() {
+    def ship = new Ship(Coordinate.of(2, 2), Coordinate.of(2, 3))
+    ship.coordinateIsHitByMissileMap.put(Coordinate.of(2, 2), true)
+
+    def newShip = shipService.copy(ship)
+    newShip.coordinateIsHitByMissileMap.put(Coordinate.of(2, 3), true)
+
+    assertFalse(ship.is(newShip))
+    assertTrue(ship.coordinateIsHitByMissileMap.get(Coordinate.of(2, 2)))
+    assertFalse(ship.coordinateIsHitByMissileMap.get(Coordinate.of(2, 3)))
+
+    assertTrue(newShip.coordinateIsHitByMissileMap.get(Coordinate.of(2, 2)))
+    assertTrue(newShip.coordinateIsHitByMissileMap.get(Coordinate.of(2, 3)))
   }
 }


### PR DESCRIPTION
Instead of modifying the Board object, return a new Board instance when a missile is sent to the Board.

Fixes: https://github.com/koraytugay/groovyship/issues/2